### PR TITLE
Add --after and --before filters on changeset dates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,19 @@ pip install .
 
 You can get basic syntax help by calling the script with `--help`.
 
-### count_highway_mappers
+### highway_mappers
 
 Counts edits to major highways by user. The result is written as a CSV file with one row per mapper and one column per highway value.
 
 The highway tag values to include are hard-coded in the script.
+
+To see options and arguments use:
+```
+python3 highway_mappers.py --help
+```
+
+The data used as input for this script are OSM history files (`.osh.pbf`) that contain all change or OSM files (`.osm.pbf`) that only contain the most recent state and change. These files can be downloaded from https://osm-internal.download.geofabrik.de/ , but please note the GDPR restrictions on use of user-data.
+
+To count edits by users over time rather than just recording the user behind the most recent change, run the script the `--all-versions` flag against an OSM history file (`*.osh.pbf`).
+
+Additional `--after <date>` and `--before <date>` filters can be passed to scope the changeset date range.

--- a/highway_mappers.py
+++ b/highway_mappers.py
@@ -1,5 +1,6 @@
 import osmium
 import click
+from datetime import datetime
 from pandas import DataFrame
 
 MAIN_HIGHWAY_KEYS = [
@@ -28,27 +29,45 @@ class MapperCounterHandler(osmium.SimpleHandler):
 
 
 class HighwayCounterHandler(osmium.SimpleHandler):
-    
-    def __init__(self, mappers, all_versions):
+
+    def __init__(self, mappers, all_versions, after, before):
         osmium.SimpleHandler.__init__(self)
         self.result = DataFrame(0, columns=MAIN_HIGHWAY_KEYS, index=mappers)
         self.all_versions = all_versions
+        self.after = after
+        self.before = before
         self.way_ids = []
         self.edits_count = 0
 
     def way(self, w):
         if 'highway' in w.tags and w.tags['highway'] in MAIN_HIGHWAY_KEYS:
-            # click.echo("id {} version {} visibe {} tags {}".format(w.id, w.version, w.visible, w.tags['highway']))
+            # click.echo("id {} version {} user {} timestamp {} visible {} tags {}".format(w.id, w.version, w.user, w.timestamp, w.visible, w.tags['highway']))
+            if self.after and self.after > w.timestamp:
+                return
+            if self.before and self.before < w.timestamp:
+                return
             if self.all_versions or w.id not in self.way_ids:
                 self.result.at[w.user, w.tags['highway']] += 1
                 self.way_ids.append(w.id)
-                self.edits_count += 1                
+                self.edits_count += 1
 
 @click.command()
 @click.option('-a', '--all-versions', is_flag=True, help='Count all previous versions (if reading a full history file)')
+@click.option('--before', default=None, is_flag=False, help='Only record changes before this date/time (ISO 8601 format). Example: --before "2022-01-01"')
+@click.option('--after', default=None, is_flag=False, help='Only record changes after this date/time (ISO 8601 format). Example: --after "2020-01-01"')
 @click.argument('osmfile', type=click.Path(exists=True))
 @click.argument('output', type=click.Path())
-def cli(osmfile, output, all_versions):
+def cli(osmfile, output, all_versions, after, before):
+    if after:
+        after = datetime.fromisoformat(after)
+        # Convert the argment to local time if no timezone is passed.
+        if after.tzinfo is None or after.tzinfo.utcoffset(after) is None:
+            after = after.astimezone()
+    if before:
+        before = datetime.fromisoformat(before)
+        # Convert the argment to local time if no timezone is passed.
+        if before.tzinfo is None or before.tzinfo.utcoffset(before) is None:
+            before = before.astimezone()
     click.echo("processing {}".format(osmfile))
     click.echo("Stage 1: Counting Unique Highway Mappers")
     mch = MapperCounterHandler()
@@ -56,7 +75,7 @@ def cli(osmfile, output, all_versions):
     click.echo("Done, {} mappers counted.".format(len(mch.mappers)))
 
     click.echo("Stage 2: Counting Highway Edits")
-    hch = HighwayCounterHandler(mappers=mch.mappers, all_versions=all_versions)
+    hch = HighwayCounterHandler(mappers=mch.mappers, all_versions=all_versions, after=after, before=before)
     hch.apply_file(osmfile)
     click.echo("Done. {} highway edits counted. Result written to {}".format(
         hch.edits_count,


### PR DESCRIPTION
These filters allow scoping of the changesets considered to a particular date range which should be useful for fetch lists of recently active highway mappers in an area.